### PR TITLE
feat: auth api 설계

### DIFF
--- a/src/main/java/com/dansup/server/auth/controller/AuthController.java
+++ b/src/main/java/com/dansup/server/auth/controller/AuthController.java
@@ -1,0 +1,28 @@
+package com.dansup.server.auth.controller;
+
+import com.dansup.server.auth.dto.request.SignUpDto;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping(value = "/auth")
+@Api(tags = "Auth API", description = "회원가입/로그인 api")
+public class AuthController {
+
+    @ApiOperation(value = "Get Kakao Login Auth Code", notes = "카카오톡 로그인 액세스 토큰 추출(프론트에서는 무시하세요)")
+    @GetMapping(value = "/signin/kakao/code")
+    public ResponseEntity<Void> authKakao(@RequestParam(value = "code", required = false) String code) {
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+
+    @ApiOperation(value = "Sign Up", notes = "회원 가입")
+    @PostMapping(value = "/signup")
+    public ResponseEntity<Void> signUp(@RequestBody SignUpDto signUpDto) {
+        return new ResponseEntity<>(HttpStatus.CREATED);
+    }
+
+}

--- a/src/main/java/com/dansup/server/auth/dto/request/GenreRequestDto.java
+++ b/src/main/java/com/dansup/server/auth/dto/request/GenreRequestDto.java
@@ -1,0 +1,7 @@
+package com.dansup.server.auth.dto.request;
+
+public class GenreRequestDto {
+
+    private String genre;
+
+}

--- a/src/main/java/com/dansup/server/auth/dto/request/HashtagRequestDto.java
+++ b/src/main/java/com/dansup/server/auth/dto/request/HashtagRequestDto.java
@@ -1,0 +1,7 @@
+package com.dansup.server.auth.dto.request;
+
+public class HashtagRequestDto {
+
+    private String hashtag;
+
+}

--- a/src/main/java/com/dansup/server/auth/dto/request/SignUpDto.java
+++ b/src/main/java/com/dansup/server/auth/dto/request/SignUpDto.java
@@ -1,0 +1,26 @@
+package com.dansup.server.auth.dto.request;
+
+import com.dansup.server.profile.dto.response.GetPortfolioDto;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+public class SignUpDto {
+
+    private MultipartFile profileImage;
+
+    private String username;
+
+    private String nickname;
+
+    private MultipartFile profileVideo;
+
+    private String intro;
+
+    private List<GenreRequestDto> genres;
+
+    private List<HashtagRequestDto> hashtags;
+
+    private List<GetPortfolioDto> portfolios;
+
+}


### PR DESCRIPTION
# 🪩 feat: auth api 설계
<br>

📌 관련 이슈
---
#7 - Auth API 구현
<!-- 관련된 이슈의 번호 및 내용 -->
<!-- ex) #1 - 마이 프로필 수정 api 구현 -->
<br>

🧭 작업 브랜치
---
feat/auth-kakao
<!-- ex) feature/profile -->
<br>

📚 작업 내용
---
auth 관련 api를 설계했습니다
<!-- ex) 마이 프로필 수정하는 api를 추가했습니다. -->
<br>

📝 상세 설명
---
- auth 관련 api를 설계했습니다
- swagger로 api를 문서화했습니다
<!-- 작업 내용 상세 설명, 질문 사항, 주의할 점 등 -->
<br>
