### PR TITLE
Feat/oauth kakao

### DIFF
--- a/src/main/java/com/dansup/server/api/auth/controller/AuthController.java
+++ b/src/main/java/com/dansup/server/api/auth/controller/AuthController.java
@@ -27,7 +27,8 @@ public class AuthController {
     @ApiOperation(value = "Sign Up", notes = "회원 가입")
     @PostMapping(value = "/sign-up")
     public ResponseEntity<Void> signUp(@AuthenticationPrincipal User user, @RequestBody SignUpDto signUpDto) {
-        authService.signin(user, signUpDto);
+        log.info("[현재 로그인한 유저]: {}", user.getEmail());
+        authService.signUp(user, signUpDto);
         return new ResponseEntity<>(HttpStatus.CREATED);
     }
 

--- a/src/main/java/com/dansup/server/api/auth/controller/AuthController.java
+++ b/src/main/java/com/dansup/server/api/auth/controller/AuthController.java
@@ -3,14 +3,13 @@ package com.dansup.server.api.auth.controller;
 import com.dansup.server.api.auth.dto.request.SignUpDto;
 import com.dansup.server.api.auth.service.AuthService;
 import com.dansup.server.api.user.domain.User;
-import com.dansup.server.config.jwt.CustomUserDetails;
+import com.dansup.server.common.AuthUser;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -27,8 +26,8 @@ public class AuthController {
 
     @ApiOperation(value = "Sign Up", notes = "회원 가입")
     @PostMapping(value = "/sign-up")
-    public ResponseEntity<Void> signUp(@AuthenticationPrincipal CustomUserDetails user, @RequestBody SignUpDto signUpDto) {
-        log.info("[현재 로그인한 유저]: {}", user.getName());
+    public ResponseEntity<Void> signUp(@AuthUser User user, @RequestBody SignUpDto signUpDto) {
+        log.info("[현재 로그인한 유저]: {}", user.getEmail());
         authService.signUp(user, signUpDto);
         return new ResponseEntity<>(HttpStatus.CREATED);
     }

--- a/src/main/java/com/dansup/server/api/auth/controller/AuthController.java
+++ b/src/main/java/com/dansup/server/api/auth/controller/AuthController.java
@@ -3,6 +3,7 @@ package com.dansup.server.api.auth.controller;
 import com.dansup.server.api.auth.dto.request.SignUpDto;
 import com.dansup.server.api.auth.service.AuthService;
 import com.dansup.server.api.user.domain.User;
+import com.dansup.server.config.jwt.CustomUserDetails;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
@@ -26,8 +27,8 @@ public class AuthController {
 
     @ApiOperation(value = "Sign Up", notes = "회원 가입")
     @PostMapping(value = "/sign-up")
-    public ResponseEntity<Void> signUp(@AuthenticationPrincipal User user, @RequestBody SignUpDto signUpDto) {
-        log.info("[현재 로그인한 유저]: {}", user.getEmail());
+    public ResponseEntity<Void> signUp(@AuthenticationPrincipal CustomUserDetails user, @RequestBody SignUpDto signUpDto) {
+        log.info("[현재 로그인한 유저]: {}", user.getName());
         authService.signUp(user, signUpDto);
         return new ResponseEntity<>(HttpStatus.CREATED);
     }

--- a/src/main/java/com/dansup/server/api/auth/dto/request/GenreRequestDto.java
+++ b/src/main/java/com/dansup/server/api/auth/dto/request/GenreRequestDto.java
@@ -1,14 +1,14 @@
 package com.dansup.server.api.auth.dto.request;
 
 import io.swagger.annotations.ApiModel;
-import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiModelProperty;
 import lombok.Getter;
 
 @Getter
 @ApiModel
 public class GenreRequestDto {
 
-    @ApiParam(value = "댄스 장트")
+    @ApiModelProperty(value = "댄스 장트")
     private String genre;
 
 }

--- a/src/main/java/com/dansup/server/api/auth/dto/request/SignUpDto.java
+++ b/src/main/java/com/dansup/server/api/auth/dto/request/SignUpDto.java
@@ -4,13 +4,20 @@ import com.dansup.server.api.profile.dto.response.GetPortfolioDto;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import io.swagger.annotations.ApiParam;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Getter
 @ApiModel
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class SignUpDto {
 
     @ApiModelProperty(value = "프로필 이미지", example = "이미지 multipartfile")
@@ -29,12 +36,15 @@ public class SignUpDto {
     private String intro;
 
     @ApiParam(value = "댄스 장르 리스트")
-    private List<GenreRequestDto> genres;
+    @Builder.Default
+    private List<GenreRequestDto> genres = new ArrayList<>();
 
     @ApiParam(value = "해시 태그 리스트")
-    private List<HashtagRequestDto> hashtags;
+    @Builder.Default
+    private List<HashtagRequestDto> hashtags = new ArrayList<>();
 
     @ApiParam(value = "경력 리스트")
-    private List<GetPortfolioDto> portfolios;
+    @Builder.Default
+    private List<GetPortfolioDto> portfolios = new ArrayList<>();
 
 }

--- a/src/main/java/com/dansup/server/api/auth/dto/request/SignUpDto.java
+++ b/src/main/java/com/dansup/server/api/auth/dto/request/SignUpDto.java
@@ -3,7 +3,6 @@ package com.dansup.server.api.auth.dto.request;
 import com.dansup.server.api.profile.dto.response.GetPortfolioDto;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-import io.swagger.annotations.ApiParam;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -26,24 +25,24 @@ public class SignUpDto {
     @ApiModelProperty(value = "계정 정보", example = "@younaring__")
     private String username;
 
-    @ApiParam(value = "댄서명", example = "유나")
+    @ApiModelProperty(value = "댄서명", example = "유나")
     private String nickname;
 
-    @ApiParam(value = "프로필 대표 영상", example = "이미지 multipartfile")
+    @ApiModelProperty(value = "프로필 대표 영상", example = "이미지 multipartfile")
     private MultipartFile profileVideo;
 
-    @ApiParam(value = "한줄 소개", example = "나는 춤이 정말 좋아")
+    @ApiModelProperty(value = "한줄 소개", example = "나는 춤이 정말 좋아")
     private String intro;
 
-    @ApiParam(value = "댄스 장르 리스트")
+    @ApiModelProperty(value = "댄스 장르 리스트")
     @Builder.Default
     private List<GenreRequestDto> genres = new ArrayList<>();
 
-    @ApiParam(value = "해시 태그 리스트")
+    @ApiModelProperty(value = "해시 태그 리스트", notes = "해시태그 3개를 모두 주셔야해요. 없으면 null로 주세요!")
     @Builder.Default
     private List<HashtagRequestDto> hashtags = new ArrayList<>();
 
-    @ApiParam(value = "경력 리스트")
+    @ApiModelProperty(value = "경력 리스트")
     @Builder.Default
     private List<GetPortfolioDto> portfolios = new ArrayList<>();
 

--- a/src/main/java/com/dansup/server/api/auth/service/AuthService.java
+++ b/src/main/java/com/dansup/server/api/auth/service/AuthService.java
@@ -23,11 +23,7 @@ public class AuthService {
     private final ProfileRepository profileRepository;
     private final UserRepository userRepository;
 
-    public void signUp(CustomUserDetails userDetails, SignUpDto signUpDto) {
-        User user = userRepository.findByEmail(userDetails.getName()).orElseThrow(
-                () -> new BaseException(ExceptionCode.USER_NOT_FOUND)
-        );
-
+    public void signUp(User user, SignUpDto signUpDto) {
         // TO DO: 파일 업로드 로직 추가해야함
         Profile profile = Profile.createProfile(user, signUpDto);
         profileRepository.save(profile);

--- a/src/main/java/com/dansup/server/api/auth/service/AuthService.java
+++ b/src/main/java/com/dansup/server/api/auth/service/AuthService.java
@@ -2,6 +2,7 @@ package com.dansup.server.api.auth.service;
 
 import com.dansup.server.api.auth.dto.request.SignUpDto;
 import com.dansup.server.api.profile.domain.Profile;
+import com.dansup.server.api.profile.repository.ProfileRepository;
 import com.dansup.server.api.user.domain.User;
 import com.dansup.server.api.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -13,11 +14,15 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class AuthService {
 
-    private UserRepository userRepository;
+    private ProfileRepository profileRepository;
 
-    public void signin(User user, SignUpDto signUpDto) {
+    public void signUp(User user, SignUpDto signUpDto) {
 
         Profile profile = Profile.createProfile(signUpDto);
+        profileRepository.save(profile);
+
+
+
 
     }
 

--- a/src/main/java/com/dansup/server/api/auth/service/AuthService.java
+++ b/src/main/java/com/dansup/server/api/auth/service/AuthService.java
@@ -4,26 +4,36 @@ import com.dansup.server.api.auth.dto.request.SignUpDto;
 import com.dansup.server.api.profile.domain.Profile;
 import com.dansup.server.api.profile.repository.ProfileRepository;
 import com.dansup.server.api.user.domain.User;
+import com.dansup.server.api.user.domain.UserRole;
 import com.dansup.server.api.user.repository.UserRepository;
+import com.dansup.server.common.exception.BaseException;
+import com.dansup.server.common.exception.ExceptionCode;
+import com.dansup.server.config.jwt.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Transactional
 @RequiredArgsConstructor
+@Slf4j
 public class AuthService {
 
-    private ProfileRepository profileRepository;
+    private final ProfileRepository profileRepository;
+    private final UserRepository userRepository;
 
-    public void signUp(User user, SignUpDto signUpDto) {
+    public void signUp(CustomUserDetails userDetails, SignUpDto signUpDto) {
+        User user = userRepository.findByEmail(userDetails.getName()).orElseThrow(
+                () -> new BaseException(ExceptionCode.USER_NOT_FOUND)
+        );
 
-        Profile profile = Profile.createProfile(signUpDto);
+        // TO DO: 파일 업로드 로직 추가해야함
+        Profile profile = Profile.createProfile(user, signUpDto);
         profileRepository.save(profile);
+        user.updateUserRole(UserRole.ROLE_USER);
 
-
-
-
+        log.info("[Sign Up 완료]: {}, {}", profile.getId(), user.getUserRole());
     }
 
 }

--- a/src/main/java/com/dansup/server/api/danceclass/dto/response/GetDanceClassDto.java
+++ b/src/main/java/com/dansup/server/api/danceclass/dto/response/GetDanceClassDto.java
@@ -16,22 +16,22 @@ public class GetDanceClassDto {
 
     //수업에서 표출되는 댄서 정보
     @ApiModelProperty(value = "강사(댄서) ID" , example = "4")
-    private final Long userId;
+    private Long userId;
     @ApiModelProperty(value = "강사(댄서) 닉네임" , example = "아이키")
-    private final String userNickname;
+    private String userNickname;
     @ApiModelProperty(value = "강사(댄서) 프로필 이미지" , example = "image")
-    private final String userProfileImage;
+    private String userProfileImage;
 
     //수업 정보
     @ApiModelProperty(value = "수업 제목" , example = "임선생의 몸치 탈출 프로젝트")
-    private final String title;
+    private String title;
     @ApiModelProperty(value = "수업 해시태그" , example = "빠른템포의")
     private List<HashtagRequestDto> hashtags;
 
     @ApiModelProperty(value = "수업 장르" , example = "락킹")
     private List<GenreRequestDto> genres;
     @ApiModelProperty(value = "수업 장소" , example = "서울특별시 강남구 00로 000")
-    private final String location;
+    private String location;
     @ApiModelProperty(value = "수업 난이도" , example = "BA")
     @NotBlank
     private String difficulty;
@@ -43,15 +43,15 @@ public class GetDanceClassDto {
     @ApiModelProperty(value = "수업 총원" , example = "10")
     private int maxPeople;
     @ApiModelProperty(value = "수업 노래 제목" , example = "뉴진스 - OMG")
-    private final String song;
+    private String song;
     @ApiModelProperty(value = "수업 추가 설명1" , example = "이런 것들을 배울 거예요")
-    private final String detail1;
+    private String detail1;
     @ApiModelProperty(value = "수업 추가 설명2" , example = "이런 분들을 위한 레슨이에요")
-    private final String detail2;
+    private String detail2;
     @ApiModelProperty(value = "수업 추가 설명3" , example = "드리는 인사말")
-    private final String detail3;
+    private String detail3;
     @ApiModelProperty(value = "수업 방식" , example = "OD")
-    private final String method;
+    private String method;
     @ApiModelProperty(value = "월요일" , example = "1")
     private boolean mon;
     @ApiModelProperty(value = "화요일" , example = "1")
@@ -67,45 +67,45 @@ public class GetDanceClassDto {
     @ApiModelProperty(value = "일요일" , example = "1")
     private boolean sun;
     @ApiModelProperty(value = "수업 시작 시간" , example = "20")
-    private final int startTime;
+    private int startTime;
     @ApiModelProperty(value = "수업 종료 시간" , example = "22")
-    private final int endTime;
+    private int endTime;
     @ApiModelProperty(value = "원데이 클래스에서의 날짜" , example = "2023/5/29")
-    private final String date;
+    private String date;
     @ApiModelProperty(value = "수업 예약 링크" , example = "com.googleform.")
-    private final String reserveLink;
+    private String reserveLink;
 
     @ApiModelProperty(value = "수업 상태(Active, Closed, Deleted" , example = "Active")
     private String state;
 
-    public GetDanceClassDto(DanceClass danceClass) {
-        this.userId = danceClass.getUser().getId();
-        this.userNickname = danceClass.getUser().getProfile().getNickname();
-        this.userProfileImage = danceClass.getUser().getProfile().getProfileImage().getUrl();
-        this.title = danceClass.getTitle();
-        this.hashtags.get(0).updateHashtag(danceClass.getHashtag1());
-        this.hashtags.get(1).updateHashtag(danceClass.getHashtag2());
-        this.hashtags.get(2).updateHashtag(danceClass.getHashtag3());
-        this.location = danceClass.getLocation();
-        this.difficulty = danceClass.getDifficulty().toString();
-        this.tuition = danceClass.getTuition();
-        this.maxPeople = danceClass.getMaxPeople();
-        this.song = danceClass.getSong();
-        this.detail1 = danceClass.getDetail1();
-        this.detail2 = danceClass.getDetail2();
-        this.detail3 = danceClass.getDetail3();
-        this.method = danceClass.getMethod().toString();
-        this.mon = danceClass.isMon();
-        this.tue = danceClass.isTue();
-        this.wed = danceClass.isWed();
-        this.thu = danceClass.isThu();
-        this.fri = danceClass.isFri();
-        this.sat = danceClass.isSat();
-        this.sun = danceClass.isSun();
-        this.startTime = danceClass.getStartTime();
-        this.endTime = danceClass.getEndTime();
-        this.date = danceClass.getDate();
-        this.reserveLink = danceClass.getReserveLink();
-        this.state = danceClass.getState().toString();
-    }
+//    public GetDanceClassDto(DanceClass danceClass) {
+//        this.userId = danceClass.getUser().getId();
+//        this.userNickname = danceClass.getUser().getProfile().getNickname();
+//        this.userProfileImage = danceClass.getUser().getProfile().getProfileImage().getUrl();
+//        this.title = danceClass.getTitle();
+//        this.hashtags.get(0).updateHashtag(danceClass.getHashtag1());
+//        this.hashtags.get(1).updateHashtag(danceClass.getHashtag2());
+//        this.hashtags.get(2).updateHashtag(danceClass.getHashtag3());
+//        this.location = danceClass.getLocation();
+//        this.difficulty = danceClass.getDifficulty().toString();
+//        this.tuition = danceClass.getTuition();
+//        this.maxPeople = danceClass.getMaxPeople();
+//        this.song = danceClass.getSong();
+//        this.detail1 = danceClass.getDetail1();
+//        this.detail2 = danceClass.getDetail2();
+//        this.detail3 = danceClass.getDetail3();
+//        this.method = danceClass.getMethod().toString();
+//        this.mon = danceClass.isMon();
+//        this.tue = danceClass.isTue();
+//        this.wed = danceClass.isWed();
+//        this.thu = danceClass.isThu();
+//        this.fri = danceClass.isFri();
+//        this.sat = danceClass.isSat();
+//        this.sun = danceClass.isSun();
+//        this.startTime = danceClass.getStartTime();
+//        this.endTime = danceClass.getEndTime();
+//        this.date = danceClass.getDate();
+//        this.reserveLink = danceClass.getReserveLink();
+//        this.state = danceClass.getState().toString();
+//    }
 }

--- a/src/main/java/com/dansup/server/api/danceclass/dto/response/GetDanceClassListDto.java
+++ b/src/main/java/com/dansup/server/api/danceclass/dto/response/GetDanceClassListDto.java
@@ -14,38 +14,38 @@ public class GetDanceClassListDto {
 
     //수업에서 표출되는 댄서 정보
     @ApiModelProperty(value = "강사(댄서) ID" , example = "4")
-    private final Long userId;
+    private Long userId;
     @ApiModelProperty(value = "강사(댄서) 닉네임" , example = "아이키")
-    private final String userNickname;
+    private String userNickname;
     @ApiModelProperty(value = "강사(댄서) 프로필 이미지" , example = "image")
-    private final String userProfileImage;
+    private String userProfileImage;
     @ApiModelProperty(value = "수업 제목" , example = "임선생의 몸치 탈출 프로젝트")
-    private final String title;
+    private String title;
     @ApiModelProperty(value = "수업 장르" , example = "락킹")
     private List<GenreRequestDto> genres;
     @ApiModelProperty(value = "수업 장소" , example = "서울특별시 강남구 00로 000")
-    private final String location;
+    private String location;
     @ApiModelProperty(value = "수업 방식" , example = "OD")
-    private final String method;
+    private String method;
 
     @ApiModelProperty(value = "수업 진행 요일" , example = "월")
     private List<DayResponseDto> days;
     @ApiModelProperty(value = "원데이 클래스에서의 날짜" , example = "2023/5/29")
-    private final String date;
+    private String date;
 
     @ApiModelProperty(value = "수업 상태(Active, Closed, Deleted" , example = "Active")
     private String state;
 
-    public GetDanceClassListDto(DanceClass danceClass) {
-        this.userId = danceClass.getUser().getId();
-        this.userNickname = danceClass.getUser().getProfile().getNickname();
-        this.userProfileImage = danceClass.getUser().getProfile().getProfileImage().getUrl();
-        this.title = danceClass.getTitle();
-        this.location = danceClass.getLocation();
-        this.method = danceClass.getMethod().toString();
-        this.date = danceClass.getDate();
-        this.state = danceClass.getState().toString();
-    }
+//    public GetDanceClassListDto(DanceClass danceClass) {
+//        this.userId = danceClass.getUser().getId();
+//        this.userNickname = danceClass.getUser().get;
+//        this.userProfileImage = danceClass.getUser().getProfile().getProfileImage().getUrl();
+//        this.title = danceClass.getTitle();
+//        this.location = danceClass.getLocation();
+//        this.method = danceClass.getMethod().toString();
+//        this.date = danceClass.getDate();
+//        this.state = danceClass.getState().toString();
+//    }
 //        if(danceClass.isMon() == true){
 //            this.days.
 //        }

--- a/src/main/java/com/dansup/server/api/profile/domain/Profile.java
+++ b/src/main/java/com/dansup/server/api/profile/domain/Profile.java
@@ -2,6 +2,7 @@ package com.dansup.server.api.profile.domain;
 
 import com.dansup.server.api.auth.dto.request.SignUpDto;
 import com.dansup.server.api.genre.domain.ProfileGenre;
+import com.dansup.server.api.user.domain.User;
 import com.dansup.server.common.BaseEntity;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -23,6 +24,10 @@ public class Profile extends BaseEntity {
     @Column(name = "profile_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
 
     @Column(nullable = false, unique = true)
     private String username;
@@ -63,6 +68,15 @@ public class Profile extends BaseEntity {
     private String hashtag3;
 
     public static Profile createProfile(SignUpDto signUpDto) {
-        return new Profile();
+        return Profile.builder()
+                .username(signUpDto.getUsername())
+                .nickname(signUpDto.getNickname())
+                .intro(signUpDto.getIntro())
+                .hashtag1(signUpDto.getHashtags().get(0).getHashtag())
+                .hashtag2(signUpDto.getHashtags().get(1).getHashtag())
+                .hashtag3(signUpDto.getHashtags().get(2).getHashtag())
+                .build();
+
+        // TO DO: 파일 업로드 로직 추가
     }
 }

--- a/src/main/java/com/dansup/server/api/profile/domain/Profile.java
+++ b/src/main/java/com/dansup/server/api/profile/domain/Profile.java
@@ -67,8 +67,9 @@ public class Profile extends BaseEntity {
     @Column(length = 5)
     private String hashtag3;
 
-    public static Profile createProfile(SignUpDto signUpDto) {
+    public static Profile createProfile(User user, SignUpDto signUpDto) {
         return Profile.builder()
+                .user(user)
                 .username(signUpDto.getUsername())
                 .nickname(signUpDto.getNickname())
                 .intro(signUpDto.getIntro())
@@ -76,7 +77,6 @@ public class Profile extends BaseEntity {
                 .hashtag2(signUpDto.getHashtags().get(1).getHashtag())
                 .hashtag3(signUpDto.getHashtags().get(2).getHashtag())
                 .build();
-
         // TO DO: 파일 업로드 로직 추가
     }
 }

--- a/src/main/java/com/dansup/server/api/user/domain/User.java
+++ b/src/main/java/com/dansup/server/api/user/domain/User.java
@@ -24,8 +24,8 @@ public class User extends BaseEntity {
     @Column(unique = true, nullable = false)
     private String email;
 
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "profile_id")
-    private Profile profile;
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private UserRole userRole;
 
 }

--- a/src/main/java/com/dansup/server/api/user/domain/User.java
+++ b/src/main/java/com/dansup/server/api/user/domain/User.java
@@ -28,4 +28,8 @@ public class User extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private UserRole userRole;
 
+    public void updateUserRole(UserRole userRole) {
+        this.userRole = userRole;
+    }
+
 }

--- a/src/main/java/com/dansup/server/api/user/domain/UserRole.java
+++ b/src/main/java/com/dansup/server/api/user/domain/UserRole.java
@@ -1,0 +1,9 @@
+package com.dansup.server.api.user.domain;
+
+import lombok.Getter;
+
+@Getter
+public enum UserRole {
+    ROLE_GUEST,
+    ROLE_USER
+}

--- a/src/main/java/com/dansup/server/api/user/service/UserService.java
+++ b/src/main/java/com/dansup/server/api/user/service/UserService.java
@@ -1,6 +1,7 @@
 package com.dansup.server.api.user.service;
 
 import com.dansup.server.api.user.domain.User;
+import com.dansup.server.api.user.domain.UserRole;
 import com.dansup.server.api.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -15,6 +16,7 @@ public class UserService {
 
     public User createOAuthUser(String email) {
         User user = User.builder()
+                .userRole(UserRole.ROLE_GUEST)
                 .email(email)
                 .build();
 

--- a/src/main/java/com/dansup/server/common/AuthUser.java
+++ b/src/main/java/com/dansup/server/common/AuthUser.java
@@ -1,0 +1,14 @@
+package com.dansup.server.common;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+@AuthenticationPrincipal(expression = "#this == 'anonymousUser' ? null : user")
+public @interface AuthUser {
+}

--- a/src/main/java/com/dansup/server/config/jwt/CustomUserDetailsServiceImpl.java
+++ b/src/main/java/com/dansup/server/config/jwt/CustomUserDetailsServiceImpl.java
@@ -4,6 +4,7 @@ import com.dansup.server.api.user.domain.User;
 import com.dansup.server.api.user.repository.UserRepository;
 import com.dansup.server.common.exception.BaseException;
 import com.dansup.server.common.exception.ExceptionCode;
+import com.dansup.server.config.security.UserAccount;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.userdetails.UserDetailsService;
@@ -26,7 +27,7 @@ public class CustomUserDetailsServiceImpl implements UserDetailsService {
         User user = userRepository.findByEmail(username)
                 .orElseThrow(() -> new BaseException(ExceptionCode.USER_NOT_FOUND));
 
-        return new CustomUserDetails(user);
+        return new UserAccount(user);
     }
 
 }

--- a/src/main/java/com/dansup/server/config/oauth/CustomOAuth2UserService.java
+++ b/src/main/java/com/dansup/server/config/oauth/CustomOAuth2UserService.java
@@ -39,6 +39,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
                     () -> new BaseException(ExceptionCode.USER_NOT_FOUND)
             );
             log.info("[카카오 유저 등록 확인] user_id: {}", user.getId());
+
         } else {
             user = userService.createOAuthUser(email);
             log.info("[카카오 유저 등록] user_id: {}", user.getId());

--- a/src/main/java/com/dansup/server/config/security/SecurityConfig.java
+++ b/src/main/java/com/dansup/server/config/security/SecurityConfig.java
@@ -57,7 +57,7 @@ public class SecurityConfig {
                 .and()
                 .authorizeRequests()
                 .antMatchers(swagger).permitAll()
-                .antMatchers("/auth/sign-in").permitAll()
+                .antMatchers("/auth/sign-up").permitAll()
                 .antMatchers(HttpMethod.GET, "/danceclasses/**").permitAll()
                 .antMatchers(HttpMethod.GET,"/profile/**").permitAll()
                 .antMatchers("/oauth2/**").permitAll()

--- a/src/main/java/com/dansup/server/config/security/UserAccount.java
+++ b/src/main/java/com/dansup/server/config/security/UserAccount.java
@@ -1,0 +1,15 @@
+package com.dansup.server.config.security;
+
+import com.dansup.server.api.user.domain.User;
+import com.dansup.server.config.jwt.CustomUserDetails;
+import lombok.Getter;
+
+@Getter
+public class UserAccount extends CustomUserDetails {
+    private final User user;
+
+    public UserAccount(User user) {
+        super(user);
+        this.user = user;
+    }
+}

--- a/src/test/java/com/dansup/server/SignUpTest.java
+++ b/src/test/java/com/dansup/server/SignUpTest.java
@@ -1,0 +1,31 @@
+package com.dansup.server;
+
+import com.dansup.server.api.user.domain.User;
+import com.dansup.server.api.user.repository.UserRepository;
+import com.dansup.server.api.user.service.UserService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+@SpringBootTest
+@Transactional
+public class SignUpTest {
+
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private UserService userService;
+
+    @Test
+    public void getUserProfile() {
+        userService.createOAuthUser("test@test.com");
+
+        User user = userRepository.findByEmail("test@test.com").get();
+
+        assertNull(user.getProfile());
+
+    }
+}

--- a/src/test/java/com/dansup/server/SignUpTest.java
+++ b/src/test/java/com/dansup/server/SignUpTest.java
@@ -1,6 +1,7 @@
 package com.dansup.server;
 
 import com.dansup.server.api.user.domain.User;
+import com.dansup.server.api.user.domain.UserRole;
 import com.dansup.server.api.user.repository.UserRepository;
 import com.dansup.server.api.user.service.UserService;
 import org.junit.jupiter.api.Test;
@@ -8,6 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 @SpringBootTest
@@ -25,7 +27,7 @@ public class SignUpTest {
 
         User user = userRepository.findByEmail("test@test.com").get();
 
-        assertNull(user.getProfile());
+        assertEquals(user.getUserRole(), UserRole.ROLE_GUEST);
 
     }
 }


### PR DESCRIPTION
# 🪩 feat: 카카오 인증 후 회원가입 로직 구현
<br>

📌 관련 이슈
---
#48 - 카카오톡 소셜 로그인 구현
<!-- 관련된 이슈의 번호 및 내용 -->
<!-- ex) #1 - 마이 프로필 수정 api 구현 -->
<br>

🧭 작업 브랜치
---
feat/oauth-kakao
<!-- ex) feature/profile -->
<br>

📚 작업 내용
---
카카오 인증 후 프로필 작성 여부를 판단하는 로직을 구현했습니다
<!-- ex) 마이 프로필 수정하는 api를 추가했습니다. -->
<br>

📝 상세 설명
---
- 기존 User에 UserRole을 추가했습니다
- 카카오 인증 후 User가 프로필을 작성했다면 `isGuest=false`, 작성하지 않았다면 `isGuest=true`가 반환됩니다 프론트에서 판단하여 프로필 작성 페이지로 전환하면 됩니다. -> 추후 논의 필요
- 기존 `@AuthenticationPrincipal` 어노테이션으로 바로 로그인한 User 객체를 가져올 수 없어서 `UserAccount`와 커스텀 어노테이션 `@AuthUser`를 통해 바로 로그인한 유저를 가져올 수 있도록 하였습니다 참고하여 코드 작성하시길 바랍니다~!
<!-- 작업 내용 상세 설명, 질문 사항, 주의할 점 등 -->
<br>
