### PR TITLE
feat: Portfolio 생성, Class 리스트 조회 구현

### DIFF
--- a/src/main/java/com/dansup/server/api/auth/dto/request/GenreRequestDto.java
+++ b/src/main/java/com/dansup/server/api/auth/dto/request/GenreRequestDto.java
@@ -2,10 +2,16 @@ package com.dansup.server.api.auth.dto.request;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @ApiModel
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class GenreRequestDto {
 
     @ApiModelProperty(value = "댄스 장르")

--- a/src/main/java/com/dansup/server/api/danceclass/controller/DanceClassController.java
+++ b/src/main/java/com/dansup/server/api/danceclass/controller/DanceClassController.java
@@ -8,6 +8,7 @@ import com.dansup.server.api.danceclass.dto.response.GetDanceClassListDto;
 import com.dansup.server.api.danceclass.service.DanceClassService;
 import com.dansup.server.api.profile.dto.response.GetFileUrlDto;
 import com.dansup.server.api.user.domain.User;
+import com.dansup.server.common.AuthUser;
 import com.dansup.server.common.response.Response;
 import com.dansup.server.common.response.ResponseCode;
 import com.dansup.server.config.s3.S3UploaderService;
@@ -25,6 +26,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -62,8 +64,12 @@ public class DanceClassController {
 
     @ApiOperation(value = "Get DanceClassList", notes = "댄스 수업 리스트 조회")
     @GetMapping(value = "")
-    public ResponseEntity<List<GetDanceClassListDto>> getDanceClassList() {
-        return ResponseEntity.ok(new ArrayList<GetDanceClassListDto>());
+    public ResponseEntity<List<GetDanceClassListDto>> getDanceClassList(@AuthUser User user) {
+        List<GetDanceClassListDto> danceClassListDto;
+        danceClassListDto = danceClassService.getAllClassList(user);
+        Collections.reverse(danceClassListDto);
+
+        return ResponseEntity.ok(danceClassListDto);
     }
 
     @ApiOperation(value = "Create DanceClass", notes = "댄스 수업 정보 등록")
@@ -71,14 +77,12 @@ public class DanceClassController {
     public Response<Void> createDanceClass(      @RequestPart(value="createDanceClassDto", required = false) CreateDanceClassDto createDanceClassDto,
                                                  @RequestPart(value="videoFile", required = false) MultipartFile videoFile,
                                                  @RequestPart(value="thumbnail", required = false) MultipartFile thumbnail,
-                                                 @AuthenticationPrincipal User user) throws IOException {
+                                                 @AuthUser User user) throws IOException {
 
         log.info("[요청 유저]: {}", user.getEmail());
         danceClassService.createClass(user, createDanceClassDto, videoFile, thumbnail);
 
         return Response.success(ResponseCode.SUCCESS_CREATED);
-        // DanceClass Entity 생성 후
-        // CreateDanceClassDto 에 담겨있는 영상을 S3에 올리고 ClassVideo Entity 생성
     }
 
     @ApiOperation(value = "Filter DanceClass", notes = "필터링(검색 or 필터)을 통한 수업 리스트 조회")

--- a/src/main/java/com/dansup/server/api/danceclass/domain/DanceClass.java
+++ b/src/main/java/com/dansup/server/api/danceclass/domain/DanceClass.java
@@ -1,5 +1,7 @@
 package com.dansup.server.api.danceclass.domain;
 
+import com.dansup.server.api.genre.domain.ClassGenre;
+import com.dansup.server.api.genre.domain.ProfileGenre;
 import com.dansup.server.api.user.domain.User;
 import com.dansup.server.common.BaseEntity;
 import lombok.AllArgsConstructor;
@@ -12,6 +14,8 @@ import org.hibernate.annotations.OnDeleteAction;
 import javax.persistence.*;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -34,6 +38,10 @@ public class DanceClass extends BaseEntity {
     @JoinColumn(name = "cv_id")
     @OnDelete(action = OnDeleteAction.CASCADE)
     private ClassVideo classVideo;
+
+    @Builder.Default
+    @OneToMany(mappedBy = "danceClass")
+    private List<ClassGenre> classGenres = new ArrayList<>();
 
     @Column(nullable = false)
     @NotBlank(message = "수업 이름은 필수 값입니다.")

--- a/src/main/java/com/dansup/server/api/danceclass/dto/response/DayResponseDto.java
+++ b/src/main/java/com/dansup/server/api/danceclass/dto/response/DayResponseDto.java
@@ -2,12 +2,18 @@ package com.dansup.server.api.danceclass.dto.response;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.NotBlank;
 
 @Getter
 @ApiModel
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class DayResponseDto {
     @ApiModelProperty(value = "수업 요일" , example = "월")
     private String day;

--- a/src/main/java/com/dansup/server/api/danceclass/dto/response/GetDanceClassListDto.java
+++ b/src/main/java/com/dansup/server/api/danceclass/dto/response/GetDanceClassListDto.java
@@ -4,12 +4,18 @@ import com.dansup.server.api.auth.dto.request.GenreRequestDto;
 import com.dansup.server.api.danceclass.domain.DanceClass;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 
 @Getter
 @ApiModel
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class GetDanceClassListDto {
 
     //수업에서 표출되는 댄서 정보

--- a/src/main/java/com/dansup/server/api/danceclass/repository/DanceClassRepository.java
+++ b/src/main/java/com/dansup/server/api/danceclass/repository/DanceClassRepository.java
@@ -1,13 +1,16 @@
 package com.dansup.server.api.danceclass.repository;
 
 import com.dansup.server.api.danceclass.domain.DanceClass;
+import com.dansup.server.api.danceclass.domain.State;
 import com.dansup.server.api.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface DanceClassRepository extends JpaRepository<DanceClass, Long> {
     Optional<DanceClass> findById(Long dance_class_id);
+    List<DanceClass> findByState(State state);
 }

--- a/src/main/java/com/dansup/server/api/danceclass/service/DanceClassService.java
+++ b/src/main/java/com/dansup/server/api/danceclass/service/DanceClassService.java
@@ -1,10 +1,19 @@
 package com.dansup.server.api.danceclass.service;
 
+import com.dansup.server.api.auth.dto.request.GenreRequestDto;
 import com.dansup.server.api.danceclass.domain.ClassVideo;
 import com.dansup.server.api.danceclass.domain.DanceClass;
+import com.dansup.server.api.danceclass.domain.State;
 import com.dansup.server.api.danceclass.dto.request.CreateDanceClassDto;
+import com.dansup.server.api.danceclass.dto.response.DayResponseDto;
+import com.dansup.server.api.danceclass.dto.response.GetDanceClassListDto;
 import com.dansup.server.api.danceclass.repository.ClassVideoRepository;
 import com.dansup.server.api.danceclass.repository.DanceClassRepository;
+import com.dansup.server.api.genre.domain.ClassGenre;
+import com.dansup.server.api.genre.respository.ClassGenreRepository;
+import com.dansup.server.api.genre.respository.GenreRepository;
+import com.dansup.server.api.profile.domain.Profile;
+import com.dansup.server.api.profile.repository.ProfileRepository;
 import com.dansup.server.api.user.domain.User;
 import com.dansup.server.config.s3.S3UploaderService;
 import lombok.RequiredArgsConstructor;
@@ -13,6 +22,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -22,6 +33,10 @@ public class DanceClassService {
 
     private final DanceClassRepository danceClassRepository;
     private final ClassVideoRepository classVideoRepository;
+
+    private final ProfileRepository profileRepository;
+    private final GenreRepository genreRepository;
+    private final ClassGenreRepository classGenreRepository;
     private final S3UploaderService s3UploaderService;
     public void createClass(User user, CreateDanceClassDto createDanceClassDto, MultipartFile videofile, MultipartFile thumbnail) throws IOException {
 
@@ -64,7 +79,71 @@ public class DanceClassService {
         danceClassRepository.save(danceClass);
 
         log.info("[DanceClass 생성 완료]: DanceClass_title = {}", danceClass.getTitle());
+
+        List<GenreRequestDto> genres = createDanceClassDto.getGenres();
+
+        for(GenreRequestDto genreRequestDto : genres) {
+            if(genreRequestDto.getGenre() != null) {
+                ClassGenre classGenre = ClassGenre.builder()
+                        .danceClass(danceClass)
+                        .genre(genreRepository.findByName(genreRequestDto.getGenre())).build();
+                classGenreRepository.save(classGenre);
+            }
+            else break;
+        }
+
+        log.info("[DanceClass 생성 완료]: DanceClass_title = {}", danceClass.getTitle());
     }
+
+    public List<GetDanceClassListDto> getAllClassList(User user){
+
+        Optional<Profile> userprofile = profileRepository.findByUser(user);
+
+        List<DanceClass> classList = new ArrayList<>();
+        List<GetDanceClassListDto> danceClassListDto = new ArrayList<>();
+
+        classList = danceClassRepository.findByState(State.Active);
+
+        for(DanceClass danceClass : classList){
+
+            List<GenreRequestDto> genreRequestDtos = new ArrayList<>();
+            List<ClassGenre> genres = classGenreRepository.findAllByDanceClass(danceClass);
+            genres.forEach(classGenre -> {
+                genreRequestDtos.add(GenreRequestDto.builder().genre(classGenre.getGenre().getName()).build());
+            });
+
+            List<DayResponseDto> days = new ArrayList<>();
+            if(danceClass.isMon())
+                days.add(DayResponseDto.builder().day("월").build());
+            if(danceClass.isTue())
+                days.add(DayResponseDto.builder().day("화").build());
+            if(danceClass.isWed())
+                days.add(DayResponseDto.builder().day("수").build());
+            if(danceClass.isThu())
+                days.add(DayResponseDto.builder().day("목").build());
+            if(danceClass.isFri())
+                days.add(DayResponseDto.builder().day("금").build());
+            if(danceClass.isSat())
+                days.add(DayResponseDto.builder().day("토").build());
+            if(danceClass.isSun())
+                days.add(DayResponseDto.builder().day("일").build());
+
+            danceClassListDto.add(GetDanceClassListDto.builder()
+                            .userId(user.getId())
+                            .userNickname(userprofile.get().getNickname())
+                            .userProfileImage(userprofile.get().getProfileImage().getUrl())
+                            .danceClassId(danceClass.getId())
+                            .title(danceClass.getTitle())
+                            .genres(genreRequestDtos)
+                            .location(danceClass.getLocation())
+                            .method(danceClass.getMethod().toString()) //method에 value 추가하기 또는 프론트와 상의하기
+                            .thumbnailUrl(danceClass.getClassVideo().getThumbnailUrl())
+                            .days(days)
+                            .date(danceClass.getDate()).build());
+        }
+        return danceClassListDto;
+    }
+
     public Optional<DanceClass> getClass(Long danceClassId){
         return danceClassRepository.findById(danceClassId);
     }

--- a/src/main/java/com/dansup/server/api/genre/domain/ClassGenre.java
+++ b/src/main/java/com/dansup/server/api/genre/domain/ClassGenre.java
@@ -1,12 +1,20 @@
 package com.dansup.server.api.genre.domain;
 
+import com.dansup.server.api.danceclass.domain.DanceClass;
+import com.dansup.server.api.profile.domain.Profile;
 import com.dansup.server.common.BaseEntity;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 
 @Entity
 @Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class ClassGenre extends BaseEntity {
 
     @Id
@@ -16,5 +24,9 @@ public class ClassGenre extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "genre_id")
     private Genre genre;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "dance_class_id")
+    private DanceClass danceClass;
 
 }

--- a/src/main/java/com/dansup/server/api/genre/respository/ClassGenreRepository.java
+++ b/src/main/java/com/dansup/server/api/genre/respository/ClassGenreRepository.java
@@ -1,10 +1,13 @@
 package com.dansup.server.api.genre.respository;
 
+import com.dansup.server.api.danceclass.domain.DanceClass;
 import com.dansup.server.api.genre.domain.ClassGenre;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface ClassGenreRepository extends JpaRepository<ClassGenre, Long> {
-
+    List<ClassGenre> findAllByDanceClass(DanceClass danceClass);
 }

--- a/src/main/java/com/dansup/server/api/genre/respository/GenreRepository.java
+++ b/src/main/java/com/dansup/server/api/genre/respository/GenreRepository.java
@@ -6,5 +6,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface GenreRepository extends JpaRepository<Genre, Long> {
-
+    Genre findByName(String genre);
 }

--- a/src/main/java/com/dansup/server/api/profile/domain/Portfolio.java
+++ b/src/main/java/com/dansup/server/api/profile/domain/Portfolio.java
@@ -1,7 +1,10 @@
 package com.dansup.server.api.profile.domain;
 
 import com.dansup.server.common.BaseEntity;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
 
@@ -9,6 +12,9 @@ import javax.persistence.*;
 
 @Entity
 @Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
 public class Portfolio extends BaseEntity {
 
     @Id

--- a/src/main/java/com/dansup/server/api/profile/repository/ProfileRepository.java
+++ b/src/main/java/com/dansup/server/api/profile/repository/ProfileRepository.java
@@ -1,10 +1,14 @@
 package com.dansup.server.api.profile.repository;
 
 import com.dansup.server.api.profile.domain.Profile;
+import com.dansup.server.api.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 @Repository
 public interface ProfileRepository extends JpaRepository<Profile, Long> {
 
+    Optional<Profile> findByUser(User user);
 }

--- a/src/main/java/com/dansup/server/api/profile/service/PortfolioService.java
+++ b/src/main/java/com/dansup/server/api/profile/service/PortfolioService.java
@@ -1,0 +1,39 @@
+package com.dansup.server.api.profile.service;
+
+import com.dansup.server.api.danceclass.dto.request.CreateDanceClassDto;
+import com.dansup.server.api.profile.domain.Portfolio;
+import com.dansup.server.api.profile.domain.Profile;
+import com.dansup.server.api.profile.dto.response.GetPortfolioDto;
+import com.dansup.server.api.profile.repository.PortfolioRepository;
+import com.dansup.server.api.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class PortfolioService {
+
+    private final PortfolioRepository portfolioRepository;
+
+    public void createPortfolio(Profile profile, List<GetPortfolioDto> portfolios){
+
+        portfolios.forEach(pf -> {
+
+            Portfolio portfolio = Portfolio.builder()
+                    .profile(profile)
+                    .date(pf.getDate())
+                    .detail(pf.getDetail())
+                    .build();
+
+            portfolioRepository.save(portfolio);
+
+            log.info("[porfolio 생성 완료]: {}", portfolio.getId());
+        });
+
+    }
+}

--- a/src/main/java/com/dansup/server/config/security/SecurityConfig.java
+++ b/src/main/java/com/dansup/server/config/security/SecurityConfig.java
@@ -59,6 +59,7 @@ public class SecurityConfig {
                 .antMatchers(swagger).permitAll()
                 .antMatchers(HttpMethod.GET, "/danceclasses/**").permitAll()
                 .antMatchers(HttpMethod.GET,"/profile/**").permitAll()
+                .antMatchers(HttpMethod.POST, "/auth/reissuance").permitAll()
                 .antMatchers("/login/**").permitAll()
                 .anyRequest().authenticated()
 


### PR DESCRIPTION
# 🪩 feat: Portfolio 생성, Class 리스트 조회 구현
<br>

📌 관련 이슈
---
#6 PortFolio 생성 로직 구현
#15 Class 리스트 조회 로직 구현
<!-- 관련된 이슈의 번호 및 내용 -->
<!-- ex) #1 - 마이 프로필 수정 api 구현 -->
<br>

🧭 작업 브랜치
---
feat/portfolio
<!-- ex) feature/profile -->
<br>

📚 작업 내용
---

<!-- ex) 마이 프로필 수정하는 api를 추가했습니다. -->
<br>

📝 상세 설명
---

<!-- 작업 내용 상세 설명, 질문 사항, 주의할 점 등 -->
<br>
