### PR TITLE
feat: refresh token 재발급 로직 변경

### DIFF
--- a/src/main/java/com/dansup/server/api/auth/controller/AuthController.java
+++ b/src/main/java/com/dansup/server/api/auth/controller/AuthController.java
@@ -50,8 +50,8 @@ public class AuthController {
 
     @ApiOperation(value = "Reissue Access Token by Refresh Token", notes = "리프레쉬 토큰을 통해 액세스 토큰 재발급")
     @PostMapping(value = "/reissuance")
-    public Response<AccessTokenDto> reissueAccessToken(@AuthUser User user, @RequestBody RefreshTokenDto refreshTokenDto) {
-        AccessTokenDto accessTokenDto = authService.reissueAccessToken(user, refreshTokenDto);
+    public Response<AccessTokenDto> reissueAccessToken(@RequestBody RefreshTokenDto refreshTokenDto) {
+        AccessTokenDto accessTokenDto = authService.reissueAccessToken(refreshTokenDto);
 
         return Response.success(ResponseCode.SUCCESS_CREATED, accessTokenDto);
     }

--- a/src/main/java/com/dansup/server/api/auth/service/AuthService.java
+++ b/src/main/java/com/dansup/server/api/auth/service/AuthService.java
@@ -82,7 +82,7 @@ public class AuthService {
         SecurityContextHolder.clearContext();
     }
 
-    public AccessTokenDto reissueAccessToken(User user, RefreshTokenDto refreshTokenDto) {
+    public AccessTokenDto reissueAccessToken(RefreshTokenDto refreshTokenDto) {
 
         if(!jwtTokenProvider.validateToken(refreshTokenDto.getRefreshToken())) {
             throw new BaseException(ResponseCode.TOKEN_NOT_VALID);
@@ -92,6 +92,14 @@ public class AuthService {
         }
 
         log.info("[reissueAccessToken] 액세스 토큰 재발급 시작");
+
+        RefreshToken refreshToken = refreshTokenRepository.findById(refreshTokenDto.getRefreshToken()).orElseThrow(
+                () -> new BaseException(ResponseCode.REFRESH_TOKEN_NOT_FOUND)
+        );
+
+        User user = userRepository.findByEmail(refreshToken.getEmail()).orElseThrow(
+                () -> new BaseException(ResponseCode.USER_NOT_FOUND)
+        );
 
         AccessTokenDto accessTokenDto = AccessTokenDto.builder()
                 .accessToken(jwtTokenProvider.createAccessToken(user.getEmail(), new Date()))

--- a/src/main/java/com/dansup/server/config/security/SecurityConfig.java
+++ b/src/main/java/com/dansup/server/config/security/SecurityConfig.java
@@ -60,6 +60,7 @@ public class SecurityConfig {
                 .antMatchers(HttpMethod.GET, "/danceclasses/**").permitAll()
                 .antMatchers(HttpMethod.GET,"/profile/**").permitAll()
                 .antMatchers(HttpMethod.POST, "/auth/reissuance").permitAll()
+                .antMatchers("/auth/reissuance").permitAll()
                 .antMatchers("/login/**").permitAll()
                 .anyRequest().authenticated()
 


### PR DESCRIPTION
# 🪩 feat: refresh token 재발급 로직 변경
<br>

📌 관련 이슈
---
#13 - auth api 설계
<!-- 관련된 이슈의 번호 및 내용 -->
<!-- ex) #1 - 마이 프로필 수정 api 구현 -->
<br>

🧭 작업 브랜치
---
feat/oauth-kakao
<!-- ex) feature/profile -->
<br>

📚 작업 내용
---
refresh token 재발급 로직 변경
<!-- ex) 마이 프로필 수정하는 api를 추가했습니다. -->
<br>

📝 상세 설명
---
- 액세스 토큰 제외
<!-- 작업 내용 상세 설명, 질문 사항, 주의할 점 등 -->
<br>
