### PR TITLE
feat:Genre Mapping 구현

### DIFF
--- a/src/main/java/com/dansup/server/api/auth/service/AuthService.java
+++ b/src/main/java/com/dansup/server/api/auth/service/AuthService.java
@@ -1,8 +1,14 @@
 package com.dansup.server.api.auth.service;
 
+import com.dansup.server.api.auth.dto.request.GenreRequestDto;
 import com.dansup.server.api.auth.dto.request.RefreshTokenDto;
 import com.dansup.server.api.auth.dto.request.SignUpDto;
 import com.dansup.server.api.auth.dto.response.AccessTokenDto;
+import com.dansup.server.api.genre.GenreService;
+import com.dansup.server.api.genre.domain.ClassGenre;
+import com.dansup.server.api.genre.domain.ProfileGenre;
+import com.dansup.server.api.genre.respository.GenreRepository;
+import com.dansup.server.api.genre.respository.ProfileGenreRepository;
 import com.dansup.server.api.profile.domain.Profile;
 import com.dansup.server.api.profile.domain.ProfileImage;
 import com.dansup.server.api.profile.domain.ProfileVideo;
@@ -28,6 +34,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 import java.util.Date;
+import java.util.List;
 
 @Service
 @Transactional
@@ -48,6 +55,8 @@ public class AuthService {
     private final ProfileImageRepository profileImageRepository;
     private final ProfileVideoRepository profileVideoRepository;
 
+    private final GenreService genreService;
+
 
     public void signUp(User user, SignUpDto signUpDto, MultipartFile profileImage, MultipartFile profileVideo) throws IOException {
 
@@ -63,6 +72,8 @@ public class AuthService {
                 .build();
 
         profileRepository.save(profile);
+
+        genreService.creatProfileGenre(signUpDto, profile);
         portfolioService.createPortfolio(profile, signUpDto.getPortfolios());
 
         findUser.updateUserRole(UserRole.ROLE_USER);

--- a/src/main/java/com/dansup/server/api/danceclass/service/DanceClassService.java
+++ b/src/main/java/com/dansup/server/api/danceclass/service/DanceClassService.java
@@ -11,6 +11,7 @@ import com.dansup.server.api.danceclass.dto.response.GetDanceClassDto;
 import com.dansup.server.api.danceclass.dto.response.GetDanceClassListDto;
 import com.dansup.server.api.danceclass.repository.ClassVideoRepository;
 import com.dansup.server.api.danceclass.repository.DanceClassRepository;
+import com.dansup.server.api.genre.GenreService;
 import com.dansup.server.api.genre.domain.ClassGenre;
 import com.dansup.server.api.genre.respository.ClassGenreRepository;
 import com.dansup.server.api.genre.respository.GenreRepository;
@@ -42,9 +43,10 @@ public class DanceClassService {
     private final ClassVideoRepository classVideoRepository;
 
     private final ProfileRepository profileRepository;
-    private final GenreRepository genreRepository;
-    private final ClassGenreRepository classGenreRepository;
     private final S3UploaderService s3UploaderService;
+
+    private final GenreService genreService;
+
     public void createClass(User user, CreateDanceClassDto createDanceClassDto, MultipartFile videofile, MultipartFile thumbnail) throws IOException {
 
         log.info("[createClass 시작]");
@@ -88,17 +90,7 @@ public class DanceClassService {
 
         log.info("[DanceClass 생성 완료]: DanceClass_title = {}", danceClass.getTitle());
 
-        List<GenreRequestDto> genres = createDanceClassDto.getGenres();
-
-        for(GenreRequestDto genreRequestDto : genres) {
-            if(genreRequestDto.getGenre() != null) {
-                ClassGenre classGenre = ClassGenre.builder()
-                        .danceClass(danceClass)
-                        .genre(genreRepository.findByName(genreRequestDto.getGenre())).build();
-                classGenreRepository.save(classGenre);
-            }
-            else break;
-        }
+        genreService.creatClassGenre(createDanceClassDto, danceClass);
 
         log.info("[DanceClass 생성 완료]: DanceClass_title = {}", danceClass.getTitle());
     }
@@ -238,5 +230,5 @@ public class DanceClassService {
 
         return getDanceClassDto;
     }
-    
+
 }

--- a/src/main/java/com/dansup/server/api/genre/GenreService.java
+++ b/src/main/java/com/dansup/server/api/genre/GenreService.java
@@ -1,0 +1,58 @@
+package com.dansup.server.api.genre;
+
+import com.dansup.server.api.auth.dto.request.GenreRequestDto;
+import com.dansup.server.api.auth.dto.request.SignUpDto;
+import com.dansup.server.api.danceclass.domain.DanceClass;
+import com.dansup.server.api.danceclass.dto.request.CreateDanceClassDto;
+import com.dansup.server.api.genre.domain.ClassGenre;
+import com.dansup.server.api.genre.domain.ProfileGenre;
+import com.dansup.server.api.genre.respository.ClassGenreRepository;
+import com.dansup.server.api.genre.respository.GenreRepository;
+import com.dansup.server.api.genre.respository.ProfileGenreRepository;
+import com.dansup.server.api.profile.domain.Profile;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class GenreService {
+
+    private final GenreRepository genreRepository;
+    private final ProfileGenreRepository profileGenreRepository;
+    private final ClassGenreRepository classGenreRepository;
+
+    public void creatProfileGenre(SignUpDto signUpDto, Profile profile){
+
+        List<GenreRequestDto> genres = signUpDto.getGenres();
+
+        for(GenreRequestDto genreRequestDto : genres) {
+            if(genreRequestDto.getGenre() != null) {
+                ProfileGenre profileGenre = ProfileGenre.builder()
+                        .profile(profile)
+                        .genre(genreRepository.findByName(genreRequestDto.getGenre())).build();
+                profileGenreRepository.save(profileGenre);
+            }
+            else break;
+        }
+    }
+
+    public void creatClassGenre(CreateDanceClassDto createDanceClassDto, DanceClass danceClass){
+
+        List<GenreRequestDto> genres = createDanceClassDto.getGenres();
+
+        for(GenreRequestDto genreRequestDto : genres) {
+            if(genreRequestDto.getGenre() != null) {
+                ClassGenre classGenre = ClassGenre.builder()
+                        .danceClass(danceClass)
+                        .genre(genreRepository.findByName(genreRequestDto.getGenre())).build();
+                classGenreRepository.save(classGenre);
+            }
+            else break;
+        }
+    }
+
+}

--- a/src/main/java/com/dansup/server/api/genre/domain/ProfileGenre.java
+++ b/src/main/java/com/dansup/server/api/genre/domain/ProfileGenre.java
@@ -2,12 +2,18 @@ package com.dansup.server.api.genre.domain;
 
 import com.dansup.server.api.profile.domain.Profile;
 import com.dansup.server.common.BaseEntity;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 
 @Entity
 @Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class ProfileGenre extends BaseEntity {
 
     @Id


### PR DESCRIPTION
# 🪩 feat:Genre Mapping 기능 구현
<br>

📌 관련 이슈
---
genre 관련 Entity 생성 로직 구현
<!-- 관련된 이슈의 번호 및 내용 -->
<!-- ex) #1 - 마이 프로필 수정 api 구현 -->
<br>

🧭 작업 브랜치
---
feat/genre
<!-- ex) feature/profile -->
<br>

📚 작업 내용
---
DanceClass, Profile의 Genre 매칭 Method 생성
<!-- ex) 마이 프로필 수정하는 api를 추가했습니다. -->
<br>

📝 상세 설명
---

<!-- 작업 내용 상세 설명, 질문 사항, 주의할 점 등 -->
<br>
