### PR TITLE
feat: 중복 계정명 에러 반환 로직 추가

### DIFF
--- a/src/main/java/com/dansup/server/api/auth/service/AuthService.java
+++ b/src/main/java/com/dansup/server/api/auth/service/AuthService.java
@@ -64,6 +64,10 @@ public class AuthService {
                 () -> new BaseException(ResponseCode.USER_NOT_FOUND)
         );
 
+        if(profileRepository.existsByUsername(signUpDto.getUsername())) {
+            throw new BaseException(ResponseCode.DUPLICATE_NICKNAME);
+        }
+
         Profile profile = Profile.builder()
                 .user(findUser)
                 .profileImage(createProfileImage(profileImage))

--- a/src/main/java/com/dansup/server/api/profile/repository/ProfileRepository.java
+++ b/src/main/java/com/dansup/server/api/profile/repository/ProfileRepository.java
@@ -15,4 +15,6 @@ public interface ProfileRepository extends JpaRepository<Profile, Long> {
     Optional<Profile> findById(Long profileId);
 
     List<Profile> findByNickname(String nickname);
+
+    boolean existsByUsername(String username);
 }

--- a/src/main/java/com/dansup/server/common/response/ResponseCode.java
+++ b/src/main/java/com/dansup/server/common/response/ResponseCode.java
@@ -25,6 +25,7 @@ public enum ResponseCode {
     USER_NOT_FOUND(UNAUTHORIZED, "사용자를 찾을 수 없습니다."),
     TOKEN_NOT_VALID(UNAUTHORIZED, "토큰 유효성 검사에 실패하였습니다."),
     ACCESS_DENIED(UNAUTHORIZED, "접근이 금지되었습니다."),
+    DUPLICATE_NICKNAME(BAD_REQUEST, "중복된 사용자 계정명입니다."),
 
     REFRESH_TOKEN_NOT_FOUND(UNAUTHORIZED, "리프레쉬 토큰이 만료되었습니다"),
 


### PR DESCRIPTION
# 🪩 feat: 중복 계정명 에러 반환 로직 추가
<br>

📌 관련 이슈
---
#13 - auth api 설계
<!-- 관련된 이슈의 번호 및 내용 -->
<!-- ex) #1 - 마이 프로필 수정 api 구현 -->
<br>

🧭 작업 브랜치
---
feat/auth
<!-- ex) feature/profile -->
<br>

📚 작업 내용
---
추가 회원가입 api에서 중복된 사용자 계정명을 입력할시 에러 반환되게 처리
<!-- ex) 마이 프로필 수정하는 api를 추가했습니다. -->
<br>

📝 상세 설명
---
- 추후 닉네임 중복 검사 api 따로 분리해야함
<!-- 작업 내용 상세 설명, 질문 사항, 주의할 점 등 -->
<br>
