### PR TITLE
feat:프로필 클래스 조회용 State 변경

### DIFF
--- a/src/main/java/com/dansup/server/api/profile/controller/ProfileController.java
+++ b/src/main/java/com/dansup/server/api/profile/controller/ProfileController.java
@@ -13,6 +13,7 @@ import com.dansup.server.common.response.ResponseCode;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -54,7 +55,7 @@ public class ProfileController {
 
     @ApiOperation(value = "Get Dancer Classes", notes = "댄서 프로필에서 운영 중인 수업 조회")
     @GetMapping(value = "/{profileId}/class")
-    public Response<List<GetDanceClassListDto>> getProfileClassList(@AuthUser User user, @PathVariable("profileId") Long profileId) {
+    public Response<List<GetDanceClassListDto>> getProfileClassList(@AuthenticationPrincipal User user, @PathVariable("profileId") Long profileId) {
         List<GetDanceClassListDto> getDanceClassListDtos = profileService.getDanceClassList(user, profileId);
         return Response.success(ResponseCode.SUCCESS_OK, getDanceClassListDtos);
     }

--- a/src/main/java/com/dansup/server/api/profile/service/ProfileService.java
+++ b/src/main/java/com/dansup/server/api/profile/service/ProfileService.java
@@ -22,6 +22,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static com.dansup.server.common.response.ResponseCode.FAIL_BAD_REQUEST;
+
 @Service
 @RequiredArgsConstructor
 @Slf4j
@@ -107,14 +109,17 @@ public class ProfileService {
         Profile profile = loadProfile(profileId);
         List<DanceClass> danceClasses;
 
-        if(profile.getUser().getId().equals(user.getId())) {
-            danceClasses = danceClassRepository.findByUserAndStateNot(profile.getUser(), State.Delete);
-            log.info("profile_id : {}, p_user_id : {}, user_id : {}", profile.getId(), profile.getUser().getId(), user.getId());
-        }
-        else {
-            danceClasses = danceClassRepository.findByState(State.Active);
-            log.info("에러");
-        }
+        danceClasses = danceClassRepository.findByState(State.Active);
+
+//        if(user == null) {
+//            danceClasses = danceClassRepository.findByState(State.Active);
+//            log.info("에러");
+//        } else if(profile.getUser().getId().equals(user.getId())) {
+//            danceClasses = danceClassRepository.findByUserAndStateNot(profile.getUser(), State.Delete);
+//            log.info("profile_id : {}, p_user_id : {}, user_id : {}", profile.getId(), profile.getUser().getId(), user.getId());
+//        } else {
+//            throw new BaseException(FAIL_BAD_REQUEST);
+//        }
 
         return danceClasses.stream().map(
                 danceClass -> GetDanceClassListDto.builder()


### PR DESCRIPTION
# 🪩 feat:프로필 클래스 조회용 State 변경
<br>

📌 관련 이슈
---
#6 Profile의 클래스 조회시 Active 클래스만 출력
<!-- 관련된 이슈의 번호 및 내용 -->
<!-- ex) #1 - 마이 프로필 수정 api 구현 -->
<br>

🧭 작업 브랜치
---
feat/danceclass
<!-- ex) feature/profile -->
<br>

📚 작업 내용
---
Profile에서 운영중인 수업 조회시 Active인 수업들만 조회가능하도록 설정
<!-- ex) 마이 프로필 수정하는 api를 추가했습니다. -->
<br>

📝 상세 설명
---

<!-- 작업 내용 상세 설명, 질문 사항, 주의할 점 등 -->
<br>
