### PR TITLE
Feat/hard delete

### DIFF
--- a/src/main/java/com/dansup/server/api/auth/controller/AuthController.java
+++ b/src/main/java/com/dansup/server/api/auth/controller/AuthController.java
@@ -4,6 +4,8 @@ import com.dansup.server.api.auth.dto.request.RefreshTokenDto;
 import com.dansup.server.api.auth.dto.request.SignUpDto;
 import com.dansup.server.api.auth.dto.response.AccessTokenDto;
 import com.dansup.server.api.auth.service.AuthService;
+import com.dansup.server.api.danceclass.service.DanceClassService;
+import com.dansup.server.api.profile.service.ProfileService;
 import com.dansup.server.api.user.domain.User;
 import com.dansup.server.common.AuthUser;
 import com.dansup.server.common.response.Response;
@@ -26,6 +28,8 @@ import java.io.IOException;
 public class AuthController {
 
     private final AuthService authService;
+    private final ProfileService profileService;
+    private final DanceClassService danceClassService;
 
     @ApiOperation(value = "Sign Up", notes = "회원 가입")
     @PostMapping(value = "/sign-up", consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
@@ -45,6 +49,18 @@ public class AuthController {
     public Response<Void> signOut(@AuthUser User user, @RequestBody RefreshTokenDto refreshTokenDto) {
         authService.signOut(user, refreshTokenDto);
 
+        return Response.success(ResponseCode.SUCCESS_OK);
+    }
+
+    @ApiOperation(value = "Delete User", notes = "탈퇴하기")
+    @PostMapping(value = "/delete")
+    public Response<Void> deleteUser(@AuthUser User user, @RequestBody RefreshTokenDto refreshTokenDto) {
+        authService.signOut(user, refreshTokenDto);
+
+        danceClassService.deleteAllClass(user);
+        profileService.deleteProfile(user);
+
+        authService.deleteUser(user);
         return Response.success(ResponseCode.SUCCESS_OK);
     }
 

--- a/src/main/java/com/dansup/server/api/auth/service/AuthService.java
+++ b/src/main/java/com/dansup/server/api/auth/service/AuthService.java
@@ -97,6 +97,15 @@ public class AuthService {
         SecurityContextHolder.clearContext();
     }
 
+    public void deleteUser(User user){
+
+        User findUser = userRepository.findByEmail(user.getEmail()).orElseThrow(
+                () -> new BaseException(ResponseCode.USER_NOT_FOUND)
+        );
+
+        userRepository.delete(findUser);
+    }
+
     public AccessTokenDto reissueAccessToken(RefreshTokenDto refreshTokenDto) {
 
         if(!jwtTokenProvider.validateToken(refreshTokenDto.getRefreshToken())) {

--- a/src/main/java/com/dansup/server/api/danceclass/domain/DanceClass.java
+++ b/src/main/java/com/dansup/server/api/danceclass/domain/DanceClass.java
@@ -30,16 +30,14 @@ public class DanceClass extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
-    @OnDelete(action = OnDeleteAction.CASCADE)
     private User user;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
     @JoinColumn(name = "cv_id")
-    @OnDelete(action = OnDeleteAction.CASCADE)
     private ClassVideo classVideo;
 
     @Builder.Default
-    @OneToMany(mappedBy = "danceClass")
+    @OneToMany(mappedBy = "danceClass", cascade = CascadeType.REMOVE)
     private List<ClassGenre> classGenres = new ArrayList<>();
 
     @Column(nullable = false)

--- a/src/main/java/com/dansup/server/api/danceclass/repository/DanceClassRepository.java
+++ b/src/main/java/com/dansup/server/api/danceclass/repository/DanceClassRepository.java
@@ -15,6 +15,7 @@ import java.util.Optional;
 public interface DanceClassRepository extends JpaRepository<DanceClass, Long>, DanceClassRepositoryCustom {
     Optional<DanceClass> findById(Long dance_class_id);
     List<DanceClass> findByState(State state);
+    List<DanceClass> findByUser(User user);
 
     List<DanceClass> findByUserAndStateNot(User user, State state);
 

--- a/src/main/java/com/dansup/server/api/danceclass/service/DanceClassService.java
+++ b/src/main/java/com/dansup/server/api/danceclass/service/DanceClassService.java
@@ -99,6 +99,18 @@ public class DanceClassService {
         return createDanceClassListDtos(danceClasses);
     }
 
+    public void deleteAllClass(User user) throws BaseException {
+        List<DanceClass> danceClasses = danceClassRepository.findByUser(user);
+
+        for (DanceClass danceClass: danceClasses) {
+            deleteClass(user, danceClass.getId());
+        }
+//        danceClasses.stream().map(danceClass -> {
+//            deleteClass(user, danceClass.getId());
+//            return null;
+//        });
+    }
+
     public void deleteClass(User user, Long classId) throws BaseException {
 
         DanceClass danceClass = loadDanceClass(classId);
@@ -106,7 +118,7 @@ public class DanceClassService {
         compareUser(danceClass, user);
 
         deleteFile(danceClass.getClassVideo().getVideoUrl());
-        danceClassRepository.deleteById(danceClass.getId());
+        danceClassRepository.delete(danceClass);
     }
 
     public void closeClass(User user, Long classId) throws BaseException{
@@ -235,13 +247,13 @@ public class DanceClassService {
         }
     }
 
-    private Profile loadProfile(User user){
+    public Profile loadProfile(User user){
         return profileRepository.findByUser(user).orElseThrow(
                 () -> new BaseException(ResponseCode.PROFILE_NOT_FOUND)
         );
     }
 
-    private void deleteFile(String ImageURL) {
+    public void deleteFile(String ImageURL) {
         if(ImageURL == null){
             return;
         }

--- a/src/main/java/com/dansup/server/api/danceclass/service/DanceClassService.java
+++ b/src/main/java/com/dansup/server/api/danceclass/service/DanceClassService.java
@@ -27,8 +27,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static com.dansup.server.common.response.ResponseCode.CLASS_NOT_FOUND;
-import static com.dansup.server.common.response.ResponseCode.FAIL_BAD_REQUEST;
+import static com.dansup.server.common.response.ResponseCode.*;
 
 @Service
 @RequiredArgsConstructor
@@ -106,8 +105,8 @@ public class DanceClassService {
 
         compareUser(danceClass, user);
 
-        danceClass.updateState(State.Delete);
-        danceClassRepository.save(danceClass);
+        deleteFile(danceClass.getClassVideo().getVideoUrl());
+        danceClassRepository.deleteById(danceClass.getId());
     }
 
     public void closeClass(User user, Long classId) throws BaseException{
@@ -232,7 +231,7 @@ public class DanceClassService {
     private void compareUser(DanceClass danceClass, User user) {
 
         if(!danceClass.getUser().getId().equals(user.getId())){
-            throw new BaseException(FAIL_BAD_REQUEST);
+            throw new BaseException(FAIL_NOT_POSTER);
         }
     }
 
@@ -240,5 +239,13 @@ public class DanceClassService {
         return profileRepository.findByUser(user).orElseThrow(
                 () -> new BaseException(ResponseCode.PROFILE_NOT_FOUND)
         );
+    }
+
+    private void deleteFile(String ImageURL) {
+        if(ImageURL == null){
+            return;
+        }
+        String ImageName = ImageURL.split("com/")[1].trim();
+        s3UploaderService.deleteFile(ImageName);
     }
 }

--- a/src/main/java/com/dansup/server/api/genre/domain/ClassGenre.java
+++ b/src/main/java/com/dansup/server/api/genre/domain/ClassGenre.java
@@ -30,7 +30,7 @@ public class ClassGenre extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "dance_class_id")
-    @OnDelete(action = OnDeleteAction.CASCADE)
+//    @OnDelete(action = OnDeleteAction.CASCADE)
     private DanceClass danceClass;
 
 }

--- a/src/main/java/com/dansup/server/api/profile/domain/Portfolio.java
+++ b/src/main/java/com/dansup/server/api/profile/domain/Portfolio.java
@@ -24,7 +24,6 @@ public class Portfolio extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "profile_id")
-    @OnDelete(action = OnDeleteAction.CASCADE)
     private Profile profile;
 
     @Column

--- a/src/main/java/com/dansup/server/api/profile/domain/PortfolioVideo.java
+++ b/src/main/java/com/dansup/server/api/profile/domain/PortfolioVideo.java
@@ -24,7 +24,6 @@ public class PortfolioVideo extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "profile_id")
-    @OnDelete(action = OnDeleteAction.CASCADE)
     private Profile profile;
 
     @Column(nullable = false)

--- a/src/main/java/com/dansup/server/api/profile/domain/Profile.java
+++ b/src/main/java/com/dansup/server/api/profile/domain/Profile.java
@@ -28,7 +28,6 @@ public class Profile extends BaseEntity {
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
-    @OnDelete(action = OnDeleteAction.CASCADE)
     private User user;
 
     @Column(nullable = false, unique = true)
@@ -40,21 +39,21 @@ public class Profile extends BaseEntity {
     @Column(length = 50)
     private String intro;
 
-    @OneToMany(mappedBy = "profile")
+    @OneToMany(mappedBy = "profile", cascade = CascadeType.REMOVE)
     private List<ProfileGenre> profileGenres = new ArrayList<>();
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
     @JoinColumn(name = "pv_id")
     private ProfileVideo profileVideo;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
     @JoinColumn(name = "pi_id")
     private ProfileImage profileImage;
 
-    @OneToMany(mappedBy = "profile")
+    @OneToMany(mappedBy = "profile", cascade = CascadeType.REMOVE)
     private List<Portfolio> portfolios = new ArrayList<>();
 
-    @OneToMany(mappedBy = "profile")
+    @OneToMany(mappedBy = "profile", cascade = CascadeType.REMOVE)
     private List<PortfolioVideo> portfolioVideos = new ArrayList<>();
 
     @Column(length = 5)

--- a/src/main/java/com/dansup/server/api/profile/service/ProfileService.java
+++ b/src/main/java/com/dansup/server/api/profile/service/ProfileService.java
@@ -180,14 +180,6 @@ public class ProfileService {
             danceClassService.deleteFile(portfolioVideo.getUrl());
         }
 
-        //문제!!!!!!!!!!!!!!!!
-//        profile.getPortfolioVideos().stream().map(
-//                portfolioVideo -> {
-//                    danceClassService.deleteFile(portfolioVideo.getUrl());
-//                    return null;
-//                }
-//        );
-
         profileRepository.delete(profile);
     }
 }

--- a/src/main/java/com/dansup/server/api/user/controller/MyPageController.java
+++ b/src/main/java/com/dansup/server/api/user/controller/MyPageController.java
@@ -56,6 +56,16 @@ public class MyPageController {
         return Response.success(ResponseCode.SUCCESS_CREATED);
     }
 
+    @ApiOperation(value = "Delete PortfolioVideo", notes = "마이페이지에서 포트폴리오 영상 삭제")
+    @DeleteMapping("/portfolio/video/{pvId}")
+    public Response<Void> deletePostPortfolioVideo(@AuthUser User user,
+                                                   @PathVariable("pvId") Long pvId) {
+
+        myPageService.deletePortfolioVideo(user, pvId);
+
+        return Response.success(ResponseCode.SUCCESS_OK);
+    }
+
     @ApiOperation(value = "Get Mypage Portfolio", notes = "마이페이지에서 포트폴리오(공연 및 활동 경력) 조회")
     @GetMapping(value = "/portfolio")
     public Response<List<GetPortfolioDto>> getPortfolioList(@AuthUser User user) {
@@ -101,10 +111,9 @@ public class MyPageController {
 
     @ApiOperation(value = "Delete DanceClass", notes = "댄스 수업 삭제")
     @DeleteMapping("/class/{danceclassId}")
-    public Response<Void> deletePost(@AuthUser User user,
-                                     @PathVariable("danceclassId") Long danceclassId) {
+    public Response<Void> deleteDanceClass(@AuthUser User user,
+                                           @PathVariable("danceclassId") Long danceclassId) {
 
-        // DanceClass 의 State 를 Deleted 로 변경
         danceClassService.deleteClass(user, danceclassId);
 
         return Response.success(ResponseCode.SUCCESS_OK);

--- a/src/main/java/com/dansup/server/api/user/service/MyPageService.java
+++ b/src/main/java/com/dansup/server/api/user/service/MyPageService.java
@@ -5,6 +5,7 @@ import com.dansup.server.api.danceclass.domain.DanceClass;
 import com.dansup.server.api.danceclass.domain.State;
 import com.dansup.server.api.danceclass.dto.response.GetDanceClassListDto;
 import com.dansup.server.api.danceclass.repository.DanceClassRepository;
+import com.dansup.server.api.danceclass.service.DanceClassService;
 import com.dansup.server.api.profile.domain.PortfolioVideo;
 import com.dansup.server.api.profile.domain.Profile;
 import com.dansup.server.api.profile.domain.ProfileVideo;
@@ -30,18 +31,18 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static com.dansup.server.common.response.ResponseCode.FAIL_NOT_POSTER;
+
 @Service
 @RequiredArgsConstructor
 @Slf4j
 @Transactional
 public class MyPageService {
 
-    private final ProfileRepository profileRepository;
-
-    private final DanceClassRepository danceClassRepository;
-
     private final S3UploaderService s3UploaderService;
-
+    private final DanceClassService danceClassService;
+    private final ProfileRepository profileRepository;
+    private final DanceClassRepository danceClassRepository;
     private final PortfolioVideoRepository portfolioVideoRepository;
 
     public GetProfileDetailDto getMyPage(User user) {
@@ -139,6 +140,18 @@ public class MyPageService {
         portfolioVideoRepository.save(portfolioVideo);
     }
 
+    public void deletePortfolioVideo(User user, Long pvId) throws BaseException {
+
+        PortfolioVideo portfolioVideo = portfolioVideoRepository.findById(pvId).orElseThrow(
+                () -> new BaseException(ResponseCode.VIDEO_NOT_FOUND)
+        );;
+
+        compareUser(portfolioVideo, user);
+
+        danceClassService.deleteFile(portfolioVideo.getUrl());
+        portfolioVideoRepository.delete(portfolioVideo);
+    }
+
     private Profile loadMyPage(User user) {
 
         return profileRepository.findByUser(user).orElseThrow(
@@ -146,4 +159,12 @@ public class MyPageService {
         );
     }
 
+    private void compareUser(PortfolioVideo portfolioVideo, User user) {
+
+        Profile profile = loadMyPage(user);
+
+        if(!portfolioVideo.getProfile().equals(profile)){
+            throw new BaseException(FAIL_NOT_POSTER);
+        }
+    }
 }

--- a/src/main/java/com/dansup/server/common/response/ResponseCode.java
+++ b/src/main/java/com/dansup/server/common/response/ResponseCode.java
@@ -18,6 +18,7 @@ public enum ResponseCode {
 
     //fail
     FAIL_BAD_REQUEST(BAD_REQUEST, "잘못된 요청입니다."),
+    FAIL_NOT_POSTER(BAD_REQUEST, "작성자가 아닙니다."),
     FAIL_SERVER_ERROR(INTERNAL_SERVER_ERROR, "서버 에러가 발생했습니다."),
 
     // Auth

--- a/src/main/java/com/dansup/server/common/response/ResponseCode.java
+++ b/src/main/java/com/dansup/server/common/response/ResponseCode.java
@@ -37,7 +37,10 @@ public enum ResponseCode {
     PROFILE_NOT_FOUND(NOT_FOUND, "존재하지 않는 프로필입니다."),
 
     //class
-    CLASS_NOT_FOUND(NOT_FOUND, "존재하지 않는 클래스입니다.");
+    CLASS_NOT_FOUND(NOT_FOUND, "존재하지 않는 클래스입니다."),
+
+    //video
+    VIDEO_NOT_FOUND(NOT_FOUND, "존재하지 않는 영상입니다.");
 
     private final HttpStatus httpStatus;
     private final String message;


### PR DESCRIPTION
# 🪩 PR 요약 <!-- feat: 유저 마이 프로필 수정 api 추가 -->
<br>
기존의 Soft Delete 방식을 Hard Delete 로 변경

📌 관련 이슈
---

<!-- 관련된 이슈의 번호 및 내용 -->
<!-- ex) #1 - 마이 프로필 수정 api 구현 -->
<br>

🧭 작업 브랜치
---

<!-- ex) feature/profile -->
<br>

📚 작업 내용
---
회원 탈퇴 API 와 포트폴리오 비디오 삭제 API 추가했습니다.
User와 Profile, DanceClass 를 Cascade.Remove로 묶었고
Profile을 관련 Entity들과, DanceClass를 관련 Entity들과 Cascade.Remove로 묶어 연결 고리를 형성했습니다.
<!-- ex) 마이 프로필 수정하는 api를 추가했습니다. -->
<br>

📝 상세 설명
---

<!-- 작업 내용 상세 설명, 질문 사항, 주의할 점 등 -->
<br>
