### PR TITLE
feat: Portfolio Video List Dto 수정(pvId 추가)

### DIFF
--- a/src/main/java/com/dansup/server/api/danceclass/controller/DanceClassController.java
+++ b/src/main/java/com/dansup/server/api/danceclass/controller/DanceClassController.java
@@ -6,7 +6,6 @@ import com.dansup.server.api.danceclass.dto.request.DanceClassFilterDto;
 import com.dansup.server.api.danceclass.dto.response.GetDanceClassDto;
 import com.dansup.server.api.danceclass.dto.response.GetDanceClassListDto;
 import com.dansup.server.api.danceclass.service.DanceClassService;
-import com.dansup.server.api.profile.dto.response.GetFileUrlDto;
 import com.dansup.server.api.user.domain.User;
 import com.dansup.server.common.AuthUser;
 import com.dansup.server.common.response.Response;

--- a/src/main/java/com/dansup/server/api/profile/dto/response/GetFileUrlDto.java
+++ b/src/main/java/com/dansup/server/api/profile/dto/response/GetFileUrlDto.java
@@ -14,6 +14,9 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class GetFileUrlDto {
 
+    @ApiModelProperty(value = "portfolio ID", example = "23")
+    private Long pvId;
+
     @ApiModelProperty(value = "file url", example = "url")
     private String url;
 

--- a/src/main/java/com/dansup/server/api/profile/service/PortfolioService.java
+++ b/src/main/java/com/dansup/server/api/profile/service/PortfolioService.java
@@ -8,7 +8,6 @@ import com.dansup.server.api.danceclass.dto.response.GetDanceClassListDto;
 import com.dansup.server.api.danceclass.repository.DanceClassRepository;
 import com.dansup.server.api.profile.domain.Portfolio;
 import com.dansup.server.api.profile.domain.Profile;
-import com.dansup.server.api.profile.dto.response.GetFileUrlDto;
 import com.dansup.server.api.profile.dto.response.GetPortfolioDto;
 import com.dansup.server.api.profile.dto.response.GetProfileDetailDto;
 import com.dansup.server.api.profile.repository.PortfolioRepository;

--- a/src/main/java/com/dansup/server/api/profile/service/ProfileService.java
+++ b/src/main/java/com/dansup/server/api/profile/service/ProfileService.java
@@ -104,6 +104,7 @@ public class ProfileService {
 
         return profile.getPortfolioVideos().stream().map(
                 portfolioVideo -> GetFileUrlDto.builder()
+                        .pvId(portfolioVideo.getId())
                         .url(portfolioVideo.getUrl())
                         .build()
         ).collect(Collectors.toList());

--- a/src/main/java/com/dansup/server/api/user/service/MyPageService.java
+++ b/src/main/java/com/dansup/server/api/user/service/MyPageService.java
@@ -86,6 +86,7 @@ public class MyPageService {
 
         return myPage.getPortfolioVideos().stream().map(
                 portfolioVideo -> GetFileUrlDto.builder()
+                        .pvId(portfolioVideo.getId())
                         .url(portfolioVideo.getUrl())
                         .build()
         ).collect(Collectors.toList());


### PR DESCRIPTION
# 🪩 PR 요약 <!-- feat: 유저 마이 프로필 수정 api 추가 -->
<br>
포트폴리오 비디오 조회를 위한 Dto에 pvId 값을 추가했습니다.
📌 관련 이슈
---

<!-- 관련된 이슈의 번호 및 내용 -->
<!-- ex) #1 - 마이 프로필 수정 api 구현 -->
<br>

🧭 작업 브랜치
---

<!-- ex) feature/profile -->
<br>

📚 작업 내용
---

<!-- ex) 마이 프로필 수정하는 api를 추가했습니다. -->
<br>

📝 상세 설명
---

<!-- 작업 내용 상세 설명, 질문 사항, 주의할 점 등 -->
<br>
